### PR TITLE
[ 박수로 ] 버그픽스 : 검색결과 클릭 시  404 에러 픽스

### DIFF
--- a/src/views/SearchPage/SearchPage.js
+++ b/src/views/SearchPage/SearchPage.js
@@ -39,7 +39,7 @@ function PostList(props) {
             <div className="community-box">
               <TableBody
                 currentList={posts.slice(firstIndex, lastIndex)}
-                match={props.match}
+                match={{ path: 1 }} // 하드 코딩 수정 필요
                 loading={loading}
               />
             </div>
@@ -69,49 +69,3 @@ function PostList(props) {
 }
 
 export default withRouter(PostList);
-
-// export function TableBody({ currentList, match, loading }) {
-//   return (
-//     <>
-//       {loading ? (
-//         <Table pagination={false} dataSource={currentList}>
-//           <Column title="-" dataIndex="id" key="id" />
-//           <Column
-//             title="제목"
-//             key="title"
-//             render={(text, record) => (
-//               <Link to={`${match.path}/${record.id}`}>
-//                 {record.title.length > 20
-//                   ? record.title.slice(0, 20)
-//                   : record.title}
-//               </Link>
-//             )}
-//           />{' '}
-//           <Column
-//             title="작성자"
-//             render={(text, record) =>
-//               record.User === null ? (
-//                 <>탈퇴한 사용자</>
-//               ) : (
-//                 <>{record.User.nickname}</>
-//               )
-//             }
-//             key="User"
-//           />
-//           <Column
-//             title="작성일"
-//             render={(text, record) =>
-//               record.createdAt ? record.createdAt.slice(0, 10) : 'none'
-//             }
-//             key="createdAt"
-//           />
-//           <Column title="추천수" dataIndex="like" key="like" />
-//         </Table>
-//       ) : (
-//         <>
-//           <Skeleton />
-//         </>
-//       )}
-//     </>
-//   );
-// }


### PR DESCRIPTION
> HUFS-WEB Project PR message template
아래 사항들을 전부 작성하고 PR 해주세요!

## 구현 사항 간략한 한줄 요약
(여기에 수정 사항에 대한 간략한 한줄 요약/제목 작성해 주세요. 예: 로그인 엔드포인트 구현)      

검색결과 클릭 시  404 에러 픽스
		 
## 구현 사항들 자세한 내용
(여기에 수정 사항에 대한 자세한 내용을 작성해 주세요)

메인페이지에서 전체 검색을 한 후 게시판을 클릭시 라우팅이 `/search/게시글번호` 로 되어 404 에러가 뜨는 것을 확인함.
PostList에서 사용하는 게시글 Table을 가져와 사용해서 나오는 에러라는 것을 확인.
라우팅을 `/1/게시글번호`로 하드코딩하여 버그 픽스항

## 구현 질문 및 특이 사항
(궁금한 사항들, 하면서 느낀 점들 공유해주실 것이 있으면 자유롭게 작성해 주세요.)

이후 `/1`로 하드코딩 했던 부분을 리팩토링 해야할 것