### PR TITLE
[노가영] 기능 수정 : 웹메일로 회원가입시 자동으로 웹메일 저장

### DIFF
--- a/src/components/login/modals/SignUpModal.js
+++ b/src/components/login/modals/SignUpModal.js
@@ -78,6 +78,15 @@ const SignUpModal = (props) => {
       });
   };
 
+  const isWebMail = (props) => {
+    var emailInfo = (submit.email).split('@');
+    if (emailInfo[1] === 'hufs.ac.kr') {
+      return emailInfo[0]
+    } else {
+      return ''
+    }
+  }
+
   const layout = {
     labelcol: { span: 8 },
     wrapperCol: { span: 16 },
@@ -128,7 +137,13 @@ const SignUpModal = (props) => {
             }}
             style={{ width: '100%' }}
           >
-            <Input style={{ textAlign: 'center' }} placeholder='@hufs.ac.kr 앞 부분까지만 입력해주세요' suffix="@hufs.ac.kr"></Input>
+            <Input 
+              style={{ textAlign: 'center' }}
+              placeholder='@hufs.ac.kr 앞 부분까지만 입력해주세요'
+              //prefix={isWebMail()}
+              suffix="@hufs.ac.kr"
+              defaultValue={isWebMail()}
+              ></Input>
           </Form.Item>
 
           <Form.Item

--- a/src/components/login/modals/SignUpModal.js
+++ b/src/components/login/modals/SignUpModal.js
@@ -78,14 +78,14 @@ const SignUpModal = (props) => {
       });
   };
 
-  // const isWebMail = (props) => {
-  //   var emailInfo = (submit.email).split('@');
-  //   if (emailInfo[1] === 'hufs.ac.kr') {
-  //     return emailInfo[0]
-  //   } else {
-  //     return ''
-  //   }
-  // }
+  const isWebMail = (props) => {
+    var emailInfo = (submit.email).split('@');
+    if (emailInfo[1] === 'hufs.ac.kr') {
+      return emailInfo[0]
+    } else {
+      return ''
+    }
+  }
 
   const layout = {
     labelcol: { span: 8 },
@@ -127,19 +127,37 @@ const SignUpModal = (props) => {
               placeholder="닉네임을 입력하세요"
             ></Input>
           </Form.Item>
-
-          {
+          <Form.Item
+            label="웹메일"
+            extra="위 웹메일로 학생 확인 인증 메일이 발송되며, 인증은 24시간이 지나면 만료됩니다 (회원 가입 후 별도로 My page에서도 가능합니다)"
+            name="webMail"
+            onChange={(event) => {
+              setSubmit({ ...submit, webMail: event.target.value });
+              // console.log(((submit.email).split('@'))[1])
+            }}
+            style={{ width: '100%' }}
+            >
+              <Input 
+              style={{ textAlign: 'center' }}
+              placeholder='@hufs.ac.kr 앞 부분까지만 입력해주세요'
+              prefix={isWebMail()}
+              suffix="@hufs.ac.kr"
+              // defaultValue={isWebMail()}
+              ></Input>
+            </Form.Item>
+          {/* {
             ((submit.email).split('@'))[1] === 'hufs.ac.kr'
-            ? <p> &nbsp;&nbsp;웹메일 &nbsp;:&nbsp;&nbsp;{submit.email}</p>
-            : 
+            ? <p> &nbsp;&nbsp;웹메일 &nbsp;:&nbsp;&nbsp;{submit.webMail}</p>
+            :
             <Form.Item
-              label="웹메일"
-              extra="위 웹메일로 학생 확인 인증 메일이 발송되며, 인증은 24시간이 지나면 만료됩니다 (회원 가입 후 별도로 My page에서도 가능합니다 )"
-              name="webMail"
-              onChange={(event) => {
-                setSubmit({ ...submit, webMail: event.target.value });
-              }}
-              style={{ width: '100%' }}
+            label="웹메일"
+            extra="위 웹메일로 학생 확인 인증 메일이 발송되며, 인증은 24시간이 지나면 만료됩니다 (회원 가입 후 별도로 My page에서도 가능합니다)"
+            name="webMail"
+            onChange={(event) => {
+              setSubmit({ ...submit, webMail: event.target.value });
+              // console.log(((submit.email).split('@'))[1])
+            }}
+            style={{ width: '100%' }}
             >
               <Input 
               style={{ textAlign: 'center' }}
@@ -149,7 +167,7 @@ const SignUpModal = (props) => {
               // defaultValue={isWebMail()}
               ></Input>
             </Form.Item>
-            }
+            } */}
 
           <Form.Item
             label="주전공"

--- a/src/components/login/modals/SignUpModal.js
+++ b/src/components/login/modals/SignUpModal.js
@@ -78,14 +78,14 @@ const SignUpModal = (props) => {
       });
   };
 
-  const isWebMail = (props) => {
-    var emailInfo = (submit.email).split('@');
-    if (emailInfo[1] === 'hufs.ac.kr') {
-      return emailInfo[0]
-    } else {
-      return ''
-    }
-  }
+  // const isWebMail = (props) => {
+  //   var emailInfo = (submit.email).split('@');
+  //   if (emailInfo[1] === 'hufs.ac.kr') {
+  //     return emailInfo[0]
+  //   } else {
+  //     return ''
+  //   }
+  // }
 
   const layout = {
     labelcol: { span: 8 },
@@ -128,23 +128,28 @@ const SignUpModal = (props) => {
             ></Input>
           </Form.Item>
 
-          <Form.Item
-            label="웹메일"
-            extra="위 웹메일로 학생 확인 인증 메일이 발송되며, 인증은 24시간이 지나면 만료됩니다 (회원 가입 후 별도로 My page에서도 가능합니다 )"
-            name="webMail"
-            onChange={(event) => {
-              setSubmit({ ...submit, webMail: event.target.value });
-            }}
-            style={{ width: '100%' }}
-          >
-            <Input 
+          {
+            ((submit.email).split('@'))[1] === 'hufs.ac.kr'
+            ? <p> &nbsp;&nbsp;웹메일 &nbsp;:&nbsp;&nbsp;{submit.email}</p>
+            : 
+            <Form.Item
+              label="웹메일"
+              extra="위 웹메일로 학생 확인 인증 메일이 발송되며, 인증은 24시간이 지나면 만료됩니다 (회원 가입 후 별도로 My page에서도 가능합니다 )"
+              name="webMail"
+              onChange={(event) => {
+                setSubmit({ ...submit, webMail: event.target.value });
+              }}
+              style={{ width: '100%' }}
+            >
+              <Input 
               style={{ textAlign: 'center' }}
               placeholder='@hufs.ac.kr 앞 부분까지만 입력해주세요'
               //prefix={isWebMail()}
               suffix="@hufs.ac.kr"
-              defaultValue={isWebMail()}
+              // defaultValue={isWebMail()}
               ></Input>
-          </Form.Item>
+            </Form.Item>
+            }
 
           <Form.Item
             label="주전공"


### PR DESCRIPTION
> HUFS-WEB Project PR message template
아래 사항들을 전부 작성하고 PR 해주세요!

## 구현 사항 간략한 한줄 요약

- 웹메일(XX.@hufs.ac.kr)로 회원가입 시도 시 자동으로 웹메일 칸에 웹메일 입력되도록 수정  

		 
## 구현 사항들 자세한 내용

- @gmail.com 사용자와 @hufs.ac.kr 사용자를 나눠 웹메일로 회원가입을 시도한 경우 바로 웹메일이 저장되도록 한다

## 구현 질문 및 특이 사항

- 현재는 입력란에 웹메일이 자동으로 기입되는데, 수정이 가능한 상태이다. 수정 불가능하도록 하려면 prefix로 하면 되는데, 그렇게 하는 것 보다 일단은 수정 가능하도록 하는 것이 낫겠다는 생각이 들었다.,,,...
- 그런데 pr을 적다 보니 더 좋은 구현 방법이 떠올랐습니다...😮 우선 시간이 늦었으니 내일 오전 중으로 다른 방법 사용할 수 있도록 수정해보겠습니다!

